### PR TITLE
Make app ready for Railway deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 
 ---
 
+## 🚀 Deployment on Railway
 
-
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Railway automatically uses the `procfile` command to start the FastAPI server.
+3. Set environment variables such as `OPENAI_API_KEY` in your Railway project settings.
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+from kgpt.agent.api import app
+
+if __name__ == "__main__":
+    import uvicorn
+    import os
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))
+

--- a/procfile
+++ b/procfile
@@ -1,1 +1,2 @@
-web: uvicorn main:app --host 0.0.0.0.--port 8000
+web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8000}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ langchain-community
 langchain_huggingface
 langchain_text_splitters
 sentence_transformers
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- create `app.py` exposing FastAPI app for uvicorn
- fix `procfile` command
- document Railway deployment
- add FastAPI/uvicorn to requirements

## Testing
- `python3 -m py_compile app.py kgpt/agent/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68516d43a8cc83219d9a6b73dbb4df94